### PR TITLE
Add wait before an alert according to Chrome update

### DIFF
--- a/test/EnvironmentCheck.java
+++ b/test/EnvironmentCheck.java
@@ -8,6 +8,9 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Wait;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 /**
  * このプログラムはハンズオンに必要なプログラムが適切にインストールされたかをチェックするプログラムです。
@@ -17,6 +20,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 public class EnvironmentCheck {
 
     private WebDriver driver;
+    private Wait<WebDriver> wait;
     
     private String chromeDriverPath() {
         String path;
@@ -33,6 +37,7 @@ public class EnvironmentCheck {
     public void setUp() {
         System.setProperty("webdriver.chrome.driver", chromeDriverPath());
         driver = new ChromeDriver();
+        wait = new WebDriverWait(driver, 30);
     }
         
     @After
@@ -51,6 +56,7 @@ public class EnvironmentCheck {
         password.sendKeys("pass");
         WebElement login = driver.findElement(By.id("login"));
         login.click();
+        wait.until(ExpectedConditions.alertIsPresent());
         driver.switchTo().alert().accept();
     }
 }


### PR DESCRIPTION
As EnvironmentCheck fails because it cannot find an alert, I added a wait procedure before asserting an alert.
The failure is not 100% regenerated, but it often fails especially on Mac.
